### PR TITLE
tur.ini update

### DIFF
--- a/ifme/lang/tur.ini
+++ b/ifme/lang/tur.ini
@@ -1,7 +1,7 @@
-﻿[Info]
+[Info]
 iso = tur
 Name = SailorOnDaTea
-Version = 0.1
+Version = 0.1.1
 Contact = http://www.facebook.com/sailorondatea
 
 [Root]
@@ -41,16 +41,16 @@ btnOptions = &Seçenekler
 btnAbout = &Hakkında
 btnStop = &Durdur
 btnResume = &Devam Et
-tabUserPreset = Kullanıcı Ön Ayar
-lblUserPreLabel = Eser|Sürüm|Web
-lblUserPreData = Preset Adı|Preset Sürüm|Preset Web
+tabUserPreset = Kullanıcı Önayarı
+lblUserPreLabel = Yazar|Sürüm|Web Sayfası
+lblUserPreData = Önayar Adı|Önayar Sürümü|Önayar Web Sayfası
 
 [AudioMethod]
 WhichMode = Sadece ilk ses akışını al|Tüm sesleri tek akışta birleştir|Çoklu ses akışı
 
 [TheList]
 FileName = Dosya adı
-Ext = Çık
+Ext = Uzantı
 Codec = Kodlayıcı
 Res = Çözünürlük
 BitDepth = Bit Derinliği
@@ -69,7 +69,7 @@ EmptyQueue = Kodlama başlayamaz. Kodlayacak bir şey yok. Lütfen bir dosya ekl
 EmptySubtitle = Kodlama başlayamaz. Altyazı etkin ama liste boş.
 EmptyAttachment = Kodlama başlayamaz. Ekler etkin ama liste boş.
 NotEqual = Kodlama başlayamaz. Kuyruk toplamı eklenti miktarıyla eşleşmelidir.
-Quit = Terketmek istiyor musunuz? Her şey kaybolacak.
+Quit = Çıkmak istiyor musunuz? Her şey kaybolacak.
 Halt = Kodlamayı durdurmak istiyor musunuz?
 InstallMsg = Dosyalar başarıyla kuruldu. Etkinleşmesi için programı yeniden başlatın.
 RemoveMsg = Bu öğeyi kaldırmak istiyor musunuz?
@@ -83,17 +83,17 @@ NotEmptyFolder = Boş bir klasör seçin.
 [TheOptions]
 tabGeneral = Genel
 grpLang = Dil
-lblLangDisplay = Çevirmen|Sürüm|Web sayfası
-lblLangWho = SailorOnDaTea|0.1|http://www.facebook.com/sailorondatea
+lblLangDisplay = Çevirmen|Sürüm|Web Sayfası
+lblLangWho = SailorOnDaTea|0.1.1|http://www.facebook.com/sailorondatea
 grpTemp = Geçici klasör
 grpFormat = Çıktı türü
 rdoUseMkv = Varsayılan
 grpUpdate = Güncelle
-chkUpdate = Her zaman kontrol et. Guncelleme varsa yeni sürümü uygula ve yeniden başlat.
+chkUpdate = Her zaman kontrol et. Güncelleme varsa yeni sürümü uygula ve yeniden başlat.
 tabPerformance = Performans
-lblCPUPriority = İşlemci önceliği
-lblCPUAffinity = İşlemci adedi
-lblCPUInfo = Intel Turbo Boost veya AMD Turbo Core'dan faydalanmak için işlemcilerinizin yarısını veya ceyreğini seçin. Bu arttırılmış saat hızından faydalanmayı garantiler.
+lblCPUPriority = İşlemci Önceliği
+lblCPUAffinity = İşlemci Adedi
+lblCPUInfo = Intel Turbo Boost veya AMD Turbo Core`dan faydalanmak için işlemcilerinizin yarısını veya ceyreğini seçin. Bu arttırılmış saat hızı kullanımını garantiler.
 btnCPUBoost = Turbo Boost/Core kullan
 tabAddons = Eklentiler
 btnAddonInstall = &Dosyadan Yükle


### PR DESCRIPTION
-Column name "Ext" fixed.(previously assumed as "Extra"). "uzantı" is correct word meaning extension.
-Several words in English (like Preset, Preset Name, Preset Web) translated correctly.
-apostrophe (') character replaced with (`) since I saw the rest of the code highighted in red on GitHub.
-"Quit" fixed.(terketmek=to leave, to get out, to abandon, to quit. çıkmak= to exit, to go out, to quit. Latter one sounds better with programs.)
-CPU settings capitalized as in English version.
-"Güncelleme" meaning "Update" is written with "ü" (like in Chinese v/ü in pinyin LvYou旅游). "u" without dots is typo.
-tur.ini version updated to 0.1.1