### PR TITLE
include stdlib.h not stdio.h

### DIFF
--- a/sources/ifme-gnome.c
+++ b/sources/ifme-gnome.c
@@ -4,7 +4,7 @@
 	terminal open just like Windows Console
 */
 
-#include <stdio.h>
+#include <stdlib.h>
 
 int main() {
 	system("chmod +x ./ifme");

--- a/sources/ifme-xterm.c
+++ b/sources/ifme-xterm.c
@@ -4,7 +4,7 @@
 	terminal open just like Windows Console
 */
 
-#include <stdio.h>
+#include <stdlib.h>
 
 int main() {
 	system("chmod +x ./ifme");


### PR DESCRIPTION
`system()` is defined in stdlib.h (see `man 3 system`).