### PR TITLE
fix Video/Audio Trimming issues:

### DIFF
--- a/IFME/CustomForms/TimespanTextBox.cs
+++ b/IFME/CustomForms/TimespanTextBox.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Drawing;
+using System.Text.RegularExpressions;
+using System.Windows.Forms;
+
+namespace IFME
+{
+    internal class TimespanTextBox : TextBox
+    {
+        private string lastValidText = "";
+        public TimeSpan? MaxValue { get; set; } = null;
+
+        public TimeSpan TimeSpan
+        {
+            get
+            {
+                TimeSpan.TryParse(this.Text, out var timeStart);
+                return timeStart;
+            }
+            set
+            {
+                setValueTimespan(value);
+            }
+        }
+
+        public TimespanTextBox()
+        {
+            this.KeyPress += new KeyPressEventHandler(this.textBox_KeyPress);
+            this.TextChanged += new EventHandler(this.textBox_Validating);
+        }
+
+        public TimespanTextBox(TimeSpan maxValue) : base()
+        {
+            this.MaxValue = maxValue;
+        }
+
+        public void setValueSeconds(float seconds)
+        {
+            setValueTimespan(TimeSpan.FromSeconds((double)(new decimal(seconds))));
+        }
+
+        private void setValueTimespan(TimeSpan timespan)
+        {
+            string sign = (timespan.TotalMilliseconds < 0) ? "-" : "";
+            this.Text = $"{sign}{timespan:hh\\:mm\\:ss\\.fff}";
+        }
+
+        private void textBox_Validating(object sender, EventArgs e)
+        {
+            if (string.IsNullOrWhiteSpace(this.Text) || this.Text.Equals("0"))
+                this.Text = "00:00:00.000";
+
+            var rTime = new Regex(@"-?[0-9][0-9]\:[0-6][0-9]\:[0-6][0-9]\.[0-9]{1,3}");
+
+            if (!rTime.IsMatch(this.Text))
+            {
+                MessageBox.Show("Please provide the time in hh:mm:ss.xxx format", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                this.Text = lastValidText;
+            }
+            else if (this.MaxValue != null && this.TimeSpan > this.MaxValue)
+            {
+                MessageBox.Show("Time set exceeds file duration", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                this.Text = lastValidText;
+            }
+            else
+            {
+                lastValidText = this.Text;
+            }
+
+            if (this.Text.Contains("-"))
+            {
+                this.BackColor = Color.PaleVioletRed;
+                this.ForeColor = Color.DarkRed;
+            } else
+            {
+                this.BackColor = TextBox.DefaultBackColor;
+                this.ForeColor = TextBox.DefaultForeColor;
+            }
+        }
+
+        private void textBox_KeyPress(object sender, KeyPressEventArgs e)
+        {
+            if (char.IsDigit(e.KeyChar) || char.IsControl(e.KeyChar) || (e.KeyChar.ToString() == ":") || (e.KeyChar.ToString() == "."))
+            {
+                e.Handled = false;
+            }
+            else
+            {
+                e.Handled = true;
+            }
+        }
+    }
+}

--- a/IFME/IFME.csproj
+++ b/IFME/IFME.csproj
@@ -60,6 +60,9 @@
     <Compile Include="BackgroundWorker2.cs">
       <SubType>Component</SubType>
     </Compile>
+    <Compile Include="CustomForms\TimespanTextBox.cs">
+      <SubType>Component</SubType>
+    </Compile>
     <Compile Include="Extensions.cs" />
     <Compile Include="Fonts\FontAwesome.cs" />
     <Compile Include="Fonts\Fonts.cs" />

--- a/IFME/frmMain.Designer.cs
+++ b/IFME/frmMain.Designer.cs
@@ -101,16 +101,16 @@
             this.chkAdvCropAuto = new System.Windows.Forms.CheckBox();
             this.grpAdvCrop = new System.Windows.Forms.GroupBox();
             this.lblAdvCropNote = new System.Windows.Forms.Label();
-            this.txtAdvCropDuration = new System.Windows.Forms.TextBox();
+            this.txtAdvCropDuration = new TimespanTextBox();
             this.lblAdvCropDuration = new System.Windows.Forms.Label();
-            this.txtAdvCropStart = new System.Windows.Forms.TextBox();
+            this.txtAdvCropStart = new TimespanTextBox();
             this.lblAdvCropStart = new System.Windows.Forms.Label();
             this.grpAdvHdr = new System.Windows.Forms.GroupBox();
             this.grpAdvTrim = new System.Windows.Forms.GroupBox();
             this.lblAdvTrimNote = new System.Windows.Forms.Label();
-            this.txtAdvTrimDuration = new System.Windows.Forms.TextBox();
-            this.txtAdvTrimEnd = new System.Windows.Forms.TextBox();
-            this.txtAdvTrimStart = new System.Windows.Forms.TextBox();
+            this.txtAdvTrimDuration = new TimespanTextBox();
+            this.txtAdvTrimEnd = new TimespanTextBox();
+            this.txtAdvTrimStart = new TimespanTextBox();
             this.lblAdvTimeEqual = new System.Windows.Forms.Label();
             this.lblAdvTimeUntil = new System.Windows.Forms.Label();
             this.lblAdvTimeEnd = new System.Windows.Forms.Label();
@@ -988,9 +988,7 @@
             this.txtAdvCropDuration.Size = new System.Drawing.Size(100, 22);
             this.txtAdvCropDuration.TabIndex = 12;
             this.txtAdvCropDuration.Text = "00:00:09.000";
-            this.txtAdvCropDuration.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.txtTrim_KeyPress);
             this.txtAdvCropDuration.Leave += new System.EventHandler(this.txtCrop_Event);
-            this.txtAdvCropDuration.Validating += new System.ComponentModel.CancelEventHandler(this.txtTrim_Validating);
             // 
             // lblAdvCropDuration
             // 
@@ -1011,9 +1009,7 @@
             this.txtAdvCropStart.Size = new System.Drawing.Size(100, 22);
             this.txtAdvCropStart.TabIndex = 10;
             this.txtAdvCropStart.Text = "00:00:05.000";
-            this.txtAdvCropStart.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.txtTrim_KeyPress);
             this.txtAdvCropStart.Leave += new System.EventHandler(this.txtCrop_Event);
-            this.txtAdvCropStart.Validating += new System.ComponentModel.CancelEventHandler(this.txtTrim_Validating);
             // 
             // lblAdvCropStart
             // 
@@ -1076,9 +1072,7 @@
             this.txtAdvTrimDuration.Size = new System.Drawing.Size(100, 22);
             this.txtAdvTrimDuration.TabIndex = 10;
             this.txtAdvTrimDuration.Text = "00:01:00.000";
-            this.txtAdvTrimDuration.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.txtTrim_KeyPress);
-            this.txtAdvTrimDuration.Leave += new System.EventHandler(this.txtTrim_Event);
-            this.txtAdvTrimDuration.Validating += new System.ComponentModel.CancelEventHandler(this.txtTrim_Validating);
+            this.txtAdvTrimDuration.Validating += new System.ComponentModel.CancelEventHandler(this.txtTrim_Event);
             // 
             // txtAdvTrimEnd
             // 
@@ -1089,9 +1083,7 @@
             this.txtAdvTrimEnd.Size = new System.Drawing.Size(100, 22);
             this.txtAdvTrimEnd.TabIndex = 9;
             this.txtAdvTrimEnd.Text = "00:10:05.000";
-            this.txtAdvTrimEnd.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.txtTrim_KeyPress);
-            this.txtAdvTrimEnd.Leave += new System.EventHandler(this.txtTrim_Event);
-            this.txtAdvTrimEnd.Validating += new System.ComponentModel.CancelEventHandler(this.txtTrim_Validating);
+            this.txtAdvTrimEnd.Validating += new System.ComponentModel.CancelEventHandler(this.txtTrim_Event);
             // 
             // txtAdvTrimStart
             // 
@@ -1102,9 +1094,7 @@
             this.txtAdvTrimStart.Size = new System.Drawing.Size(100, 22);
             this.txtAdvTrimStart.TabIndex = 8;
             this.txtAdvTrimStart.Text = "00:09:45.500";
-            this.txtAdvTrimStart.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.txtTrim_KeyPress);
-            this.txtAdvTrimStart.Leave += new System.EventHandler(this.txtTrim_Event);
-            this.txtAdvTrimStart.Validating += new System.ComponentModel.CancelEventHandler(this.txtTrim_Validating);
+            this.txtAdvTrimStart.Validating += new System.ComponentModel.CancelEventHandler(this.txtTrim_Event);
             // 
             // lblAdvTimeEqual
             // 
@@ -2266,9 +2256,9 @@
         private System.Windows.Forms.ColumnHeader colVideoPixFmt;
         private System.Windows.Forms.ColumnHeader colAudioSampleRate;
         private System.Windows.Forms.ColumnHeader colAudioChannel;
-        private System.Windows.Forms.TextBox txtAdvTrimDuration;
-        private System.Windows.Forms.TextBox txtAdvTrimEnd;
-        private System.Windows.Forms.TextBox txtAdvTrimStart;
+        private TimespanTextBox txtAdvTrimDuration;
+        private TimespanTextBox txtAdvTrimEnd;
+        private TimespanTextBox txtAdvTrimStart;
         private System.Windows.Forms.GroupBox grpAdvHdr;
         private System.Windows.Forms.CheckBox chkAudioMP4Compt;
         private System.Windows.Forms.CheckBox chkVideoMP4Compt;
@@ -2276,9 +2266,9 @@
         private System.Windows.Forms.ToolStripMenuItem tsmiUseAsIngestStation;
         private System.Windows.Forms.GroupBox grpAdvCrop;
         private System.Windows.Forms.CheckBox chkAdvCropAuto;
-        private System.Windows.Forms.TextBox txtAdvCropDuration;
+        private TimespanTextBox txtAdvCropDuration;
         private System.Windows.Forms.Label lblAdvCropDuration;
-        private System.Windows.Forms.TextBox txtAdvCropStart;
+        private TimespanTextBox txtAdvCropStart;
         private System.Windows.Forms.Label lblAdvCropStart;
         private System.Windows.Forms.Label lblAdvCropNote;
         private System.Windows.Forms.Label lblAdvTrimNote;


### PR DESCRIPTION
- Now the TimeSpan values adjust in almost every case
- When a file is seltected it automatically sets End and Duration to the original file Duration
- if all fields have time = 0, resets End and Duration to the original file Duration
- Allows a lower End Time than Start time, but shows Duration time in RED color and negative values (prevents unintended/wrong positive duration times)
- Doesn't allow values higher than original File Duration
- Fully deleting a field resets it to 0 instead of showing error